### PR TITLE
Properly sets fallback locale

### DIFF
--- a/app/code/community/Hackathon/LocaleFallback/Model/Translate.php
+++ b/app/code/community/Hackathon/LocaleFallback/Model/Translate.php
@@ -102,6 +102,7 @@ class Hackathon_LocaleFallback_Model_Translate extends Mage_Core_Model_Translate
 
             // set locale fallback
             $this->setLocale($localeFallback);
+            Mage::getSingleton('core/locale')->setLocale($localeFallback);
 
             // load translations as usual
             foreach ($this->getModulesConfig() as $moduleName => $info) {
@@ -115,6 +116,7 @@ class Hackathon_LocaleFallback_Model_Translate extends Mage_Core_Model_Translate
             $this->_loadDbTranslation($forceReload);
 
             // restore original locale
+            Mage::getSingleton('core/locale')->setLocale($tmp_locale_original);
             $this->setLocale($tmp_locale_original);
         }
 


### PR DESCRIPTION
Before this commit the locale fallback didn't work for theme translations.
The `_loadThemeTranslation` method doesn't rely on the `core/translate` model's locale but uses the `Mage::app()->getLocale()` method which, in turns, uses the `core/locale` singleton.